### PR TITLE
add ruling support for svg 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,8 +124,7 @@ function checkArgType (rawText, optionalArgs) {
     return false
   }
   if (typeof (optionalArgs.ruled) === 'boolean' && typeof (optionalArgs
-    .outputtype) === 'undefined' && Object.keys(optionalArgs).length !==
-        1) {
+    .outputtype) === 'undefined' && Object.keys(optionalArgs).length > 2) {
     return false
   }
   if (typeof (optionalArgs.ruled) === 'undefined' && typeof (optionalArgs
@@ -230,6 +229,11 @@ function vectorPdf (str, ruled, width) {
       })
       doc.translate(-180 * width, -500)
     })
+    if (ruled) {
+      for (const i in page) {
+        doc.moveTo(0, 700 + i * 500).lineTo(23800 / adjustScaleX, 700 + i * 500).stroke()
+      }
+    }
   })
   doc.end()
   return doc

--- a/utils/test_svg.js
+++ b/utils/test_svg.js
@@ -16,3 +16,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id semper neque
 handwritten(rawtext, { vector: true }).then((converted) => {
   converted.pipe(fs.createWriteStream('output_svg.pdf'))
 }).then(() => console.log('ended'))
+handwritten(rawtext, { vector: true, ruled: true }).then((converted) => {
+  converted.pipe(fs.createWriteStream('output_svg_ruled.pdf'))
+}).then(() => console.log('ended'))


### PR DESCRIPTION
Here is the ruling support with svg. Here is an example of the output : [svg with rule](https://github.com/alias-rahil/handwritten.js/files/5336302/output_svg_ruled.pdf)
It is implemented by drawing lines directly with pdfkit without using the 'margin' images as it is done otherwise.

I made some change to the function 'checkArgType' to make it work with minimal effort. Because of this the function may not catch all wrong configuration.
